### PR TITLE
Bump DecentHolograms version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
         <!--        Connector Versions-->
         <holographicdisplays.version>2.4.9</holographicdisplays.version>
-        <decentholograms.version>2.3.1</decentholograms.version>
+        <decentholograms.version>2.7.2</decentholograms.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Bump DecentHolograms API to the latest version. Newer versions of the plugin have had major performance improvements.